### PR TITLE
Issue #15: Add support for rewriting target address

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ USAGE
     [--dev eth1...] \
     [--multicast 224.0.0.251] \
     [-s <spoof_source_ip>]
+    [-t <overridden_target_ip>]
 ```
 
 - udp-broadcast-relay-redux must be run as root to be able to create a raw
@@ -40,6 +41,8 @@ USAGE
   is unusual.
 - A special source ip of `-s 1.1.1.1` can be used to set the source ip
   to the address of the outgoing interface.
+- A special destination ip of `-t 255.255.255.255` can be used to set the
+  overriden target ip to the broadcast address of the outgoing interface.
 - `-f` will fork the application to the background.
 
 EXAMPLE
@@ -61,6 +64,21 @@ EXAMPLE
 
 #### Warcraft 3 Server Discovery
 `./udp-broadcast-relay-redux --id 1 --port 6112 --dev eth0 --dev eth1`
+
+#### Relaying broadcasts between two LANs joined by tun-based VPN
+This example is from OpenWRT. Tun-based devices don't forward broadcast packets
+ so temporarily rewriting the destination address (and then re-writing it back)
+ is necessary.
+
+Router 1 (source):
+
+`./udp-broadcast-relay-redux --id 1 --port 6112 --dev br-lan --dev tun0 -t 10.66.2.13`
+
+(where 10.66.2.13 is the IP of router 2 over the tun0 link)
+
+Router 2 (target):
+
+`./udp-broadcast-relay-redux --id 2 --port 6112 --dev br-lan --dev tun0 -t 255.255.255.255`
 
 Note about firewall rules
 ---

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ USAGE
     --dev eth0 \
     [--dev eth1...] \
     [--multicast 224.0.0.251] \
-    [-s <spoof_source_ip>]
+    [-s <spoof_source_ip>] \
     [-t <overridden_target_ip>]
 ```
 

--- a/main.c
+++ b/main.c
@@ -86,6 +86,7 @@ int main(int argc,char **argv) {
     char* interfaceNames[MAXIFS];
     int interfaceNamesNum = 0;
     in_addr_t spoof_addr = 0;
+    in_addr_t target_addr_override = 0;
 
     /* Address broadcast packet was sent from */
     struct sockaddr_in rcv_addr;
@@ -102,7 +103,7 @@ int main(int argc,char **argv) {
     rcv_msg.msg_controllen = sizeof(pkt_infos);
 
     if(argc < 2) {
-        fprintf(stderr,"usage: %s [-d] [-f] [-s IP] [--id id] [--port udp-port] [--dev dev1]... [--multicast ip]...\n\n",*argv);
+        fprintf(stderr,"usage: %s [-d] [-f] [-s IP] [-t IP] [--id id] [--port udp-port] [--dev dev1]... [--multicast ip]...\n\n",*argv);
         fprintf(stderr,"This program listens for broadcast  packets  on the  specified UDP port\n"
             "and then forwards them to each other given interface.  Packets are sent\n"
             "such that they appear to have come from the original broadcaster, resp.\n"
@@ -116,6 +117,8 @@ int main(int argc,char **argv) {
             "            (helps in some rare cases)\n"
             "            Setting to 1.1.1.2 uses outgoing interface address and source port.\n"
             "            (helps in some rare cases)\n"
+            "    -t      sets the destination IP of forwarded packets; otherwise the\n"
+            "            original target is used\n"
             "\n"
         );
         exit(1);
@@ -141,10 +144,20 @@ int main(int argc,char **argv) {
             i++;
             spoof_addr = inet_addr(argv[i]);
             if (spoof_addr == INADDR_NONE) {
-                fprintf (stderr,"invalid IP address: %s\n", argv[i]);
+                fprintf (stderr,"invalid source IP address: %s\n", argv[i]);
                 exit(1);
             }
             DPRINT ("Outgoing source IP set to %s\n", argv[i]);
+        }
+        else if (strcmp(argv[i],"-t") == 0) {
+            struct in_addr converted;
+            i++;
+            if (inet_aton(argv[i], &converted) == 0) {
+                fprintf (stderr,"invalid target IP address: %s\n", argv[i]);
+                exit(1);
+            }
+            target_addr_override = converted.s_addr;
+            DPRINT ("Outgoing target IP set to %s\n", argv[i]);
         }
         else if (strcmp(argv[i],"--id") == 0) {
             i++;
@@ -540,7 +553,16 @@ int main(int argc,char **argv) {
             }
 
             struct in_addr toAddress;
-            if (rcv_inaddr.s_addr == INADDR_BROADCAST
+            if (target_addr_override) {
+                // user instructed us to override the target IP address
+                if (target_addr_override == INADDR_BROADCAST) {
+                    // rewrite to new interface broadcast addr if user specified 255.255.255.0
+                    toAddress = iface->dstaddr;
+                } else {
+                    // else rewrite to specified value
+                    toAddress.s_addr = target_addr_override;
+                }
+            } else if (rcv_inaddr.s_addr == INADDR_BROADCAST
                 || rcv_inaddr.s_addr == fromIface->dstaddr.s_addr) {
                 // Received on interface broadcast address -- rewrite to new interface broadcast addr
                 toAddress = iface->dstaddr;

--- a/main.c
+++ b/main.c
@@ -118,7 +118,9 @@ int main(int argc,char **argv) {
             "            Setting to 1.1.1.2 uses outgoing interface address and source port.\n"
             "            (helps in some rare cases)\n"
             "    -t      sets the destination IP of forwarded packets; otherwise the\n"
-            "            original target is used\n"
+            "            original target is used.\n"
+            "            Setting to 255.255.255.255 uses the broadcast address of the\n"
+            "            outgoing interface.\n"
             "\n"
         );
         exit(1);

--- a/main.c
+++ b/main.c
@@ -556,7 +556,7 @@ int main(int argc,char **argv) {
             if (target_addr_override) {
                 // user instructed us to override the target IP address
                 if (target_addr_override == INADDR_BROADCAST) {
-                    // rewrite to new interface broadcast addr if user specified 255.255.255.0
+                    // rewrite to new interface broadcast addr if user specified 255.255.255.255
                     toAddress = iface->dstaddr;
                 } else {
                     // else rewrite to specified value


### PR DESCRIPTION
In the case of trying to forward broadcast packets over tun-based VPNs, the tun interfaces unfortunately don't support broadcast packets. A workaround is to rewrite the outbound packet's destination address to be the remote router's IP address. And then that router would rewrite the packet's destination address to the broadcast address.

Admittedly I'm kinda a noob at C programming but I *hope* I did this right?
