### PR TITLE
Remove underscores in name variable

### DIFF
--- a/usage-notes/pfsense-config/udp-broadcast-relay.sh
+++ b/usage-notes/pfsense-config/udp-broadcast-relay.sh
@@ -8,7 +8,7 @@
 . /etc/rc.subr
 
 # note that rcvar is in the /etc/rc.conf.local file to enable/disable the bouncer
-name="udp-broadcast-relay"
+name="udp_broadcast_relay"
 rcvar="udp_broadcast_relay_enable"
 start_cmd="udp_broadcast_relay_start"
 stop_cmd="udp_broadcast_relay_stop"


### PR DESCRIPTION
In FreeBSD 12 (pfSense 2.5) this script no longer works because of [this issue](https://forums.freebsd.org/threads/ezjails-admin-flavour_setup-fails-under-freebsd-13.81932/), with the root cause being the dashes in the `name` variable value. This uses underscores instead, which solves the issue and is also the standard.